### PR TITLE
With timer peripheral

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,22 +74,22 @@ ASSUMPTIONS:
 #define INCREMENT_DUR 100     // Duration of a lighting increment in ms
 
 // Color of port side nav lights (0x00rrggbb)
-#define NAV_LIGHT_P_COLOR       0x00FF0000
+#define NAV_LIGHT_P_COLOR 0x00FF0000
 // Color of starboard side nav lights (0x00rrggbb)
-#define NAV_LIGHT_S_COLOR       0x0000FF00
+#define NAV_LIGHT_S_COLOR 0x0000FF00
 
 // Color of beacon lights (0x00rrggbb)
-#define BEA_LIGHT_COLOR         0x00FF0000
+#define BEA_LIGHT_COLOR   0x00FF0000
 
 // Beacon strobe timings
 #define BEA_LIGHT_INCR_HI 12  // Duration beacon lights will be on each strobe (in increments)
 #define BEA_LIGHT_INCR_LO 12  // Duration beacon lights will be off each strobe (in increments)
 
 // Color of anti-collision lights (0x00rrggbb)
-#define COL_LIGHT_COLOR       0x00FFFFFF
+#define COL_LIGHT_COLOR   0x00FFFFFF
 
 // Color of off lights -- should always be 0x00000000
-#define OFF_COLOR             0x00000000
+#define OFF_COLOR         0x00000000
 
 // Anti-collision strobe timings
 #define COL_LIGHT_INCR_HI 10  // Duration anti-collision lights will be on each strobe (in increments)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@ ASSUMPTIONS:
 // Port/Starboard config pins, MUST BE ON GPIO PORT A
 #define DIR_JUMP_PIN_O_BITMASK  PIN2_bm
 #define DIR_JUMP_PIN_I_BITMASK  PIN3_bm
+#define DIR_JUMP_PIN_I_
 #define DIR_JUMP_PIN_I_CONTROL  PORTA_PIN3CTRL  // Ensure correct port and pin
 
 // Neopixel connection
@@ -56,6 +57,11 @@ ASSUMPTIONS:
 #define B_OFFSET 2
 #define G_OFFSET 0
 
+// ==================== MAGIC NUMBERS ==================== //
+
+// for setting and clearing global interrupt bit
+#define GLOBAL_INTERRUPT_BITMASK      0x80
+#define GLOBAL_INTERRUPT_BITMASK_INV  ~GLOBAL_INTERRUPT_BITMASK
 
 // ==================== LIGHTING CONFIGURATION ==================== //
 // The total strobe times of the beacon lights and anti-collision lights
@@ -71,7 +77,14 @@ ASSUMPTIONS:
 // in counter state is reset.
 
 // Light cycle duration configuration
-#define INCREMENT_DUR 100     // Duration of a lighting increment in ms
+// this is which value the 16-bit counter should roll over at. with 20MHz clock
+// and 1024 prescale, counter will count up once every (1024 / 20,000,000)s.
+// Therefore, 0x0000 -> 0s increments, 0xFFFF -> 3.35544s. 
+// To find the overflow value for a given time between 0 and 3.355 seconds, use
+// the formula: overflow val = desired time * (20,000,000 / 1024)
+// eg:
+//      100ms -> overflow val = 1953
+#define INCREMENT_OVERFLOW 1953 // ~100ms
 
 // Color of port side nav lights (0x00rrggbb)
 #define NAV_LIGHT_P_COLOR 0x00FF0000
@@ -120,6 +133,10 @@ uint8_t col_dur_in_state = 0;
 bool bea_state = false;
 bool col_state = false;
 
+// tracker to count how many increments have passed without lighting updates
+// should never climb above 1 but who knows
+volatile int increment_updates_needed = 0;
+
 void setup() {
   // Checking if starboard jumper is present
   // Doing some register level manipulation of GPIO to avoid costly Arduino calls
@@ -139,62 +156,88 @@ void setup() {
   flight_lights.setPixelColor(NAV_LIGHT_A_IDX, nav_color);
   flight_lights.setPixelColor(NAV_LIGHT_B_IDX, nav_color);
   flight_lights.show();
+
+  // Setting up timer a 0 to generate an interrupt every now and then
+  // please note that PWM will NOT work since MegaTinyCore would typically use
+  // tca0 for PWM
+  takeOverTCA0();
+  TCA0_SINGLE_PER  = 0xFFFF;
+  TCA0_SINGLE_CTRLB = 0x00;  // periodic interrupt mode
+
+  // div1024 prescale, enabling clock
+  // means we will have (1024/20MHz) * 2^16 = 3.355s maximum interval period
+  // see 20.5.1 in datasheet
+  TCA0_SINGLE_CTRLA = 0b00000011;
+
+  TCA0_SINGLE_INTCTRL = 0b00000001; // enable overflow interrupt
+
 }
 
 void loop() {
-  // If we've been in the current state as long as we should be
-  if (bea_dur_in_state >= (bea_state ? BEA_LIGHT_INCR_HI : BEA_LIGHT_INCR_LO)) {
-    // Switching to other state
-    bea_state = !bea_state;
+  while (increment_updates_needed > 0) {
+    bea_dur_in_state++;
+    col_dur_in_state++;
 
-    // Special case when beacon is should be in next state for zero increments
-    // must immediately switch back to prior state
-    if (0 == bea_state ? BEA_LIGHT_INCR_HI : BEA_LIGHT_INCR_LO)
+    // If we've been in the current state as long as we should be
+    if (bea_dur_in_state >= (bea_state ? BEA_LIGHT_INCR_HI : BEA_LIGHT_INCR_LO)) {
+      // Switching to other state
       bea_state = !bea_state;
-    
-    // Changing color of pixel based on new state
-    if (!bea_state) {
-      flight_lights.setPixelColor(BEA_LIGHT_A_IDX, BEA_LIGHT_COLOR);
-      flight_lights.setPixelColor(BEA_LIGHT_B_IDX, BEA_LIGHT_COLOR);
-    }
-    else {
-      flight_lights.setPixelColor(BEA_LIGHT_A_IDX, OFF_COLOR);
-      flight_lights.setPixelColor(BEA_LIGHT_B_IDX, OFF_COLOR);
-    }
-    flight_lights.show();
 
-    // Reseting duration in current state
-    bea_dur_in_state = 0;
-  }
+      // Special case when beacon is should be in next state for zero increments
+      // must immediately switch back to prior state
+      if (0 == bea_state ? BEA_LIGHT_INCR_HI : BEA_LIGHT_INCR_LO)
+        bea_state = !bea_state;
+      
+      // Changing color of pixel based on new state
+      if (!bea_state) {
+        flight_lights.setPixelColor(BEA_LIGHT_A_IDX, BEA_LIGHT_COLOR);
+        flight_lights.setPixelColor(BEA_LIGHT_B_IDX, BEA_LIGHT_COLOR);
+      }
+      else {
+        flight_lights.setPixelColor(BEA_LIGHT_A_IDX, OFF_COLOR);
+        flight_lights.setPixelColor(BEA_LIGHT_B_IDX, OFF_COLOR);
+      }
+      flight_lights.show();
 
-  // If we've been in the current state as long as we should be
-  if (col_dur_in_state >= (col_state ? COL_LIGHT_INCR_HI : COL_LIGHT_INCR_LO)) {
-    // Switching to other state
-    col_state = !col_state;
-    
-    // Special case when beacon is should be in next state for zero increments
-    // must immediately switch back to prior state
-    if (0 == col_state ? COL_LIGHT_INCR_HI : COL_LIGHT_INCR_LO)
+      // Reseting duration in current state
+      bea_dur_in_state = 0;
+    }
+
+    // If we've been in the current state as long as we should be
+    if (col_dur_in_state >= (col_state ? COL_LIGHT_INCR_HI : COL_LIGHT_INCR_LO)) {
+      // Switching to other state
       col_state = !col_state;
+      
+      // Special case when beacon is should be in next state for zero increments
+      // must immediately switch back to prior state
+      if (0 == col_state ? COL_LIGHT_INCR_HI : COL_LIGHT_INCR_LO)
+        col_state = !col_state;
 
-    // Changing color of pixel based on new state
-    if (!col_state) {
-      flight_lights.setPixelColor(COL_LIGHT_A_IDX, COL_LIGHT_COLOR);
-      flight_lights.setPixelColor(COL_LIGHT_B_IDX, COL_LIGHT_COLOR);
-    } else {
-      flight_lights.setPixelColor(COL_LIGHT_A_IDX, OFF_COLOR);
-      flight_lights.setPixelColor(COL_LIGHT_B_IDX, OFF_COLOR);
+      // Changing color of pixel based on new state
+      if (!col_state) {
+        flight_lights.setPixelColor(COL_LIGHT_A_IDX, COL_LIGHT_COLOR);
+        flight_lights.setPixelColor(COL_LIGHT_B_IDX, COL_LIGHT_COLOR);
+      } else {
+        flight_lights.setPixelColor(COL_LIGHT_A_IDX, OFF_COLOR);
+        flight_lights.setPixelColor(COL_LIGHT_B_IDX, OFF_COLOR);
+      }
+      flight_lights.show();
+
+      // Reseting duration in current state
+      col_dur_in_state = 0;
     }
-    flight_lights.show();
 
-    // Reseting duration in current state
-    col_dur_in_state = 0;
+    // disabling interrupts to avoid race conditions
+    SREG &= GLOBAL_INTERRUPT_BITMASK_INV; // setting global interrupt bit to 0
+    increment_updates_needed -= 1;
+    SREG |= GLOBAL_INTERRUPT_BITMASK;     // setting global interrupt bit to 1
   }
+}
 
-  // Waiting for our increment to complete
-  delay(INCREMENT_DUR);
+// todo: add 1 to increment
+ISR(TCA0_OVF_vect) {
+  increment_updates_needed += 1;
 
-  // Incrementing time we've spent in the current state for blinking lights
-  bea_dur_in_state++;
-  col_dur_in_state++;
+  // manually clearing interrupt flag, not done in hardware
+  TCA0_SINGLE_INTFLAGS &= 0b11111110;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,6 +146,11 @@ void loop() {
   if (bea_dur_in_state >= (bea_state ? BEA_LIGHT_INCR_HI : BEA_LIGHT_INCR_LO)) {
     // Switching to other state
     bea_state = !bea_state;
+
+    // Special case when beacon is should be in next state for zero increments
+    // must immediately switch back to prior state
+    if (0 == bea_state ? BEA_LIGHT_INCR_HI : BEA_LIGHT_INCR_LO)
+      bea_state = !bea_state;
     
     // Changing color of pixel based on new state
     if (!bea_state) {
@@ -167,6 +172,11 @@ void loop() {
     // Switching to other state
     col_state = !col_state;
     
+    // Special case when beacon is should be in next state for zero increments
+    // must immediately switch back to prior state
+    if (0 == col_state ? COL_LIGHT_INCR_HI : COL_LIGHT_INCR_LO)
+      col_state = !col_state;
+
     // Changing color of pixel based on new state
     if (!col_state) {
       flight_lights.setPixelColor(COL_LIGHT_A_IDX, COL_LIGHT_COLOR);


### PR DESCRIPTION
Switching over to use of the timer peripheral for flash timing. Won't reduce timing jitter but should eliminate any error between boards from error stacking up on the delay() calls that were eliminated. I don't have access to the boards so I have no idea if this will work lol

Also sneaking in an tiny formatting change and a bug fix on an edge case for when a flash should last 0 increments.